### PR TITLE
fix "Launching App" message

### DIFF
--- a/frontend/core.js
+++ b/frontend/core.js
@@ -287,7 +287,7 @@
       titleText.appendChild(document.createTextNode(data.name));
 
       var title = document.createElement('span');
-      title.appendChild(document.createTextNode('Launching'));
+      title.appendChild(document.createTextNode('Launching '));
       title.appendChild(titleText);
       title.appendChild(document.createTextNode('...'));
 


### PR DESCRIPTION
When launching an app, for example CodeMirror, message is "LaunchingCodeMirror...".
this pull request aims to put a space between "Launching" and the app name.
