### PR TITLE
fix path for FS:xhr request

### DIFF
--- a/src/client/javascript/vfs/internal.js
+++ b/src/client/javascript/vfs/internal.js
@@ -192,7 +192,7 @@
       if ( typeof item === 'string' ) {
         item = new OSjs.VFS.File(item);
       }
-      return base + '/get' + item.path;
+      return base + '/get/' + item.path;
     }
     return base + '/upload';
   }


### PR DESCRIPTION
A FS:xhr request ends up in the handler with for example a path like this:
"/FS/gethome:///.packages/packages.json"
This will change it into
"/FS/get/home:///.packages/packages.json"

The object that ends up in the handler is
{ url: "/FS/gethome:///.packages/packages.json" }
This information is a bit double as it is already in FS
maybe a object like this would be better
{ method: 'get', path:"home:///.packages/packages.json" }
I think even the property method: 'get' can be omitted as i think all requests done this way are gets.
In the handler i make sure the request goes to the right path for my particular backend
