### PR TITLE
Window: not allow window to resize top of the window over panel

### DIFF
--- a/src/client/javascript/windowmanager.js
+++ b/src/client/javascript/windowmanager.js
@@ -281,6 +281,11 @@
         resizeMap[current.direction]();
       }
 
+      if ( newTop < current.rectWorkspace.top && newTop !== null ) {
+        newTop = current.rectWorkspace.top;
+        newHeight -= current.rectWorkspace.top - mousePosition.y;
+      }
+
       return {left: newLeft, top: newTop, width: newWidth, height: newHeight};
     }
 


### PR DESCRIPTION
Like moving, resizing also should limit the top size

Signed-off-by: drzix <korea.drzix@gmail.com>