### PR TITLE
Fix the typo in Application Chooser

### DIFF
--- a/src/client/javascript/dialogs/applicationchooser.js
+++ b/src/client/javascript/dialogs/applicationchooser.js
@@ -89,7 +89,7 @@
     var file = '<unknown file>';
     var label = '<unknown mime>';
     if ( this.args.file ) {
-      file = Utils.format('{0} ({1}', this.args.file.filename, this.args.file.mime);
+      file = Utils.format('{0} ({1})', this.args.file.filename, this.args.file.mime);
       label = API._('DIALOG_APPCHOOSER_SET_DEFAULT', this.args.file.mime);
     }
 


### PR DESCRIPTION
Hi, Anders!

I found the missed typo in Application Chooser.

The file name and mime type is displayed, 
but the bracket which wrap the mime type isn't closed.

Thanks you!