### PR TITLE
Bcrypt support for nodejs mysql handler

### DIFF
--- a/src/server/node/handlers/mysql/handler.js
+++ b/src/server/node/handlers/mysql/handler.js
@@ -30,7 +30,7 @@
  * @author  Anders Evenrud <andersevenrud@gmail.com>
  * @licence Simplified BSD License
  */
-(function(mysql) {
+(function(mysql, bcrypt) {
   'use strict';
   var connection;
 
@@ -43,6 +43,11 @@
     user     : 'osjs',
     password : 'osjs',
     database : 'osjs'
+  };
+
+  var PASSWORD_CONFIG = {
+    bcrypt    : false,
+    signature : '\$2a$1'
   };
 
   /////////////////////////////////////////////////////////////////////////////
@@ -74,43 +79,80 @@
       return;
     }
 
-    var q = 'SELECT `id`, `username`, `name`, `groups`, `settings` FROM `users` WHERE `username` = ? AND `password` = ? LIMIT 1;';
-    var a = [login.username, login.password];
+    function getUserInfo() {
+      var q = 'SELECT `id`, `username`, `name`, `groups`, `settings` FROM `osjs_users` WHERE `username` = ? LIMIT 1;';
+      var a = [login.username];
+
+      connection.query(q, a, function(err, rows, fields) {
+        if ( err ) {
+          console.error(err);
+          callback(err.Error);
+          return;
+        } else {
+          if ( rows[0] ) {
+            var row = rows[0];
+            var settings = {};
+            var groups = [];
+
+            try {
+              settings = JSON.parse(row.settings);
+            } catch ( e ) {
+              console.log('failed to parse settings', e);
+            }
+
+            try {
+              groups = JSON.parse(row.groups);
+            } catch ( e ) {
+              console.log('failed to parse groups', e);
+            }
+
+            complete({
+              id: parseInt(row.id, 10),
+              username: row.username,
+              name: row.name,
+              groups: groups,
+              settings: settings
+            });
+            return;
+          }
+        }
+
+        invalid();
+      });
+    }
+
+    var q = 'SELECT `password` FROM `osjs_users` WHERE `username` = ? LIMIT 1;';
+    var a = [login.username];
 
     connection.query(q, a, function(err, rows, fields) {
       if ( err ) {
-        console.error(err.toString());
-        callback(err.toString());
+        console.error(err);
+        callback(err.Error);
         return;
       } else {
         if ( rows[0] ) {
           var row = rows[0];
-          var settings = {};
-          var groups = [];
 
-          try {
-            settings = JSON.parse(row.settings);
-          } catch ( e ) {
-            console.log('failed to parse settings', e);
+          if ( PASSWORD_CONFIG.bcrypt === true ) {
+            var hash = row.password.replace(/^\$2y(.+)$/i, PASSWORD_CONFIG.signature);
+            bcrypt.compare(login.password, hash, function(err, res) {
+              if ( res === true ) {
+                getUserInfo();
+              } else {
+                invalid();
+              }
+            });
+            return;
+          } else {
+            if ( row.password === login.password ) {
+              getUserInfo();
+            } else {
+              invalid();
+            }
           }
-
-          try {
-            groups = JSON.parse(row.groups);
-          } catch ( e ) {
-            console.log('failed to parse groups', e);
-          }
-
-          complete({
-            id: parseInt(row.id, 10),
-            username: row.username,
-            name: row.name,
-            groups: groups,
-            settings: settings
-          });
           return;
         }
       }
-
       invalid();
     });
   };
@@ -199,4 +241,4 @@
     return new MysqlHandler();
   };
 
-})(require('mysql'));
+})(require('mysql'), require('bcryptjs'));

--- a/src/server/node/handlers/mysql/handler.js
+++ b/src/server/node/handlers/mysql/handler.js
@@ -45,11 +45,6 @@
     database : 'osjs'
   };
 
-  var PASSWORD_CONFIG = {
-    bcrypt    : false,
-    signature : '\$2a$1'
-  };
-
   /////////////////////////////////////////////////////////////////////////////
   // USER SESSION ABSTRACTION
   /////////////////////////////////////////////////////////////////////////////
@@ -132,24 +127,14 @@
       } else {
         if ( rows[0] ) {
           var row = rows[0];
-
-          if ( PASSWORD_CONFIG.bcrypt === true ) {
-            var hash = row.password.replace(/^\$2y(.+)$/i, PASSWORD_CONFIG.signature);
-            bcrypt.compare(login.password, hash, function(err, res) {
-              if ( res === true ) {
-                getUserInfo();
-              } else {
-                invalid();
-              }
-            });
-            return;
-          } else {
-            if ( row.password === login.password ) {
+          var hash = row.password.replace(/^\$2y(.+)$/i, '\$2a$1');
+          bcrypt.compare(login.password, hash, function(err, res) {
+            if ( res === true ) {
               getUserInfo();
             } else {
               invalid();
             }
-          }
+          });
           return;
         }
       }


### PR DESCRIPTION
Hello,

I've added the bcrypt support for nodejs mysql handler

*By default it's disabled* for ensure the compatibility previous versions

To enable it change `PASSWORD_CONFIG.bcrypt` to `true`

Also if the signature is not the same than your bcrypt requirements you can change it with the attribute
`PASSWORD_CONFIG.signature`

And for using bcrypt you need to install the package with this command `npm install bcryptjs`

Thanks you.