### PR TITLE
delete shortCutKey `o` and `s`

### DIFF
--- a/src/client/javascript/init.js
+++ b/src/client/javascript/init.js
@@ -171,8 +171,6 @@
           } else {
             return 'save';
           }
-        } else if ( ev.keyCode === 79 || ev.keyCode === 83 ) {
-          return 'open';
         }
         return false;
       }


### PR DESCRIPTION
hi

In textPad and any editor (exclude Write), I can't press `o` and `s` key.　
When I pres these keys, the filemanager is open or confirm dialog come in.
Why are just `s` and `o` key include `function checkShortcut` and return "open"?