### PR TITLE
Update mysql-handler.md

### DIFF
--- a/doc/mysql-handler.md
+++ b/doc/mysql-handler.md
@@ -4,7 +4,7 @@ With the *mysql* handler you can enable a login prompt for OS.js.
 
 ```
 # Install node dependency
-$ npm install node-mysql bcryptjs
+$ npm install mysql bcryptjs
 
 # Change `handler` to `mysql`.
 $ grunt config:set:handler:mysql


### PR DESCRIPTION
require('mysql') !! not require('node-mysql')

previous config had this error when bin\win-start-dist.cmd :

` 
TypeError: mysql.createConnection is not a function
    at DefaultHandler.MysqlHandler.onServerStart (C:\Users\User\Desktop\OS.js\src\server\node\handlers\mysql\handler.js:206:28)
    at Object.module.exports.listen (C:\Users\User\Desktop\OS.js\src\server\node\http.js:308:22)
    at C:\Users\User\Desktop\OS.js\src\server\node\server.js:55:11
    at Object.<anonymous> (C:\Users\User\Desktop\OS.js\src\server\node\server.js:63:3)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:136:18)
`
