### PR TITLE
OS.js needs libgtk-3-dev which is not installed by default

### DIFF
--- a/doc/X11.md
+++ b/doc/X11.md
@@ -13,7 +13,7 @@ OS.js can run as a **X11** Desktop.
 $ sudo apt-get install nodejs nodejs-legacy npm virtualbox-guest-x11
 $ sudo apt-get install xorg xauth xcursor-themes consolekit dbus dbus-x11 libwebkitgtk-3.0 libwebkitgtk-3.0-dev ligbwebkitgtk-dev 
 $ sudo apt-get install alsa-utils pulseaudio pulseaudio-module-x11 gstreamer0.10-alsa gstreamer0.10-pulseaudio gstreamer0.10-plugins-good gstreamer0.10-plugins-base
-$ sudo apt-get install build-essential libpam0g-dev
+$ sudo apt-get install build-essential libpam0g-dev libgtk-3-dev
 $ sudo npm install -g grunt-cli
 
 #


### PR DESCRIPTION
OS.js needs libgtk-3-dev which is not installed by default