### PR TITLE
displays the user's login window to the disconnect

### DIFF
--- a/doc/handler-mysql.md
+++ b/doc/handler-mysql.md
@@ -66,3 +66,9 @@ node bin/mysql-user.js add myadminaccount admin
 mkdir vfs/home/myadminaccount
 
 ```
+
+# displays the user's login window to the disconnection
+grunt config:set:client.ReloadOnShutdown:true
+grunt config
+
+```


### PR DESCRIPTION
Proposed changes in this pull-request:

-+
+# displays the user's login window to the disconnection
+grunt config:set:client.ReloadOnShutdown:true
+grunt config
+
+```

-
-

---

*Please make sure that you read the guidelines and test your code before submission, or else your request might be rejected*

