### PR TITLE
- Moved the default menu in CoreWM/menu.js to conf/140-windowmanager.json …

### DIFF
--- a/src/conf/140-windowmanager.json
+++ b/src/conf/140-windowmanager.json
@@ -8,6 +8,18 @@
           "mediaQueries": {
             "mobile": 320,
             "tablet": 800
+          },
+          "menu":{
+            "development" : {"icon": "categories/package_development.png", "title": "Development"},
+            "education"   : {"icon": "categories/applications-sience.png", "title": "Education"},
+            "games"       : {"icon": "categories/package_games.png",       "title": "Games"},
+            "graphics"    : {"icon": "categories/package_graphics.png",    "title": "Graphics"},
+            "network"     : {"icon": "categories/package_network.png",     "title": "Network"},
+            "multimedia"  : {"icon": "categories/package_multimedia.png",  "title": "Multimedia"},
+            "office"      : {"icon": "categories/package_office.png",      "title": "Office"},
+            "system"      : {"icon": "categories/package_system.png",      "title": "System"},
+            "utilities"   : {"icon": "categories/package_utilities.png",   "title": "Utilities"},
+            "unknown"     : {"icon": "categories/applications-other.png",  "title": "Other"}
           }
         }
       }

--- a/src/packages/default/CoreWM/menu.js
+++ b/src/packages/default/CoreWM/menu.js
@@ -34,7 +34,7 @@
   * rdenniston 08/03/2016
   * Move the default menu into the config file 140-windowmanager.json
   */
-  var DefaultCategories = API.getConfig("WM.args.defaults.menu");
+  var DefaultCategories = API.getConfig('WM.args.defaults.menu');
 
   function _createIcon(aiter, aname, arg) {
     return API.getIcon(aiter.icon, arg, aiter);

--- a/src/packages/default/CoreWM/menu.js
+++ b/src/packages/default/CoreWM/menu.js
@@ -30,18 +30,11 @@
 (function(WindowManager, Window, GUI, Utils, API, VFS) {
   'use strict';
 
-  var DefaultCategories = {
-    development : {icon: 'categories/package_development.png', title: 'Development'},
-    education   : {icon: 'categories/applications-sience.png', title: 'Education'},
-    games       : {icon: 'categories/package_games.png',       title: 'Games'},
-    graphics    : {icon: 'categories/package_graphics.png',    title: 'Graphics'},
-    network     : {icon: 'categories/package_network.png',     title: 'Network'},
-    multimedia  : {icon: 'categories/package_multimedia.png',  title: 'Multimedia'},
-    office      : {icon: 'categories/package_office.png',      title: 'Office'},
-    system      : {icon: 'categories/package_system.png',      title: 'System'},
-    utilities   : {icon: 'categories/package_utilities.png',   title: 'Utilities'},
-    unknown     : {icon: 'categories/applications-other.png',  title: 'Other'}
-  };
+  /*
+  * rdenniston 08/03/2016
+  * Move the default menu into the config file 140-windowmanager.json
+  */
+  var DefaultCategories = API.getConfig("WM.args.defaults.menu");
 
   function _createIcon(aiter, aname, arg) {
     return API.getIcon(aiter.icon, arg, aiter);


### PR DESCRIPTION
Proposed changes in this pull-request:

This pull-request effectively moves the default menu in the CoreWM package found in menu.js to the configuration file 140-windowmanager.json
---

*Please make sure that you read the guidelines and test your code before submission, or else your request might be rejected*

…in conf file