### PR TITLE
Fix path for asserts for the dark theme

### DIFF
--- a/src/client/themes/styles/dark/style.less
+++ b/src/client/themes/styles/dark/style.less
@@ -29,82 +29,82 @@
 
 /* Max */
 application-window-button-maximize {
-  background : url('default/wm/maximize_unfocused.png') no-repeat center center,
-               url('default/wm/maximize.png') no-repeat center center !important;
+  background : url('dark/wm/maximize_unfocused.png') no-repeat center center,
+               url('dark/wm/maximize.png') no-repeat center center !important;
 }
 application-window-button-maximize:hover {
-  background : url('default/wm/maximize_unfocused_prelight.png') no-repeat center center,
-               url('default/wm/maximize.png') no-repeat center center !important;
+  background : url('dark/wm/maximize_unfocused_prelight.png') no-repeat center center,
+               url('dark/wm/maximize.png') no-repeat center center !important;
 }
 application-window-button-maximize:active {
-  background : url('default/wm/maximize_unfocused_pressed.png') no-repeat center center,
-               url('default/wm/maximize.png') no-repeat center center !important;
+  background : url('dark/wm/maximize_unfocused_pressed.png') no-repeat center center,
+               url('dark/wm/maximize.png') no-repeat center center !important;
 }
 
 application-window[data-focused="true"] application-window-button-maximize {
-  background : url('default/wm/maximize_focused_normal.png') no-repeat center center,
-               url('default/wm/maximize.png') no-repeat center center !important;
+  background : url('dark/wm/maximize_focused_normal.png') no-repeat center center,
+               url('dark/wm/maximize.png') no-repeat center center !important;
 }
 application-window[data-focused="true"] application-window-button-maximize:hover {
-  background : url('default/wm/maximize_focused_prelight.png') no-repeat center center,
-               url('default/wm/maximize.png') no-repeat center center !important;
+  background : url('dark/wm/maximize_focused_prelight.png') no-repeat center center,
+               url('dark/wm/maximize.png') no-repeat center center !important;
 }
 application-window[data-focused="true"] application-window-button-maximize:active {
-  background : url('default/wm/maximize_focused_pressed.png') no-repeat center center,
-               url('default/wm/maximize.png') no-repeat center center !important;
+  background : url('dark/wm/maximize_focused_pressed.png') no-repeat center center,
+               url('dark/wm/maximize.png') no-repeat center center !important;
 }
 
 /* Min */
 application-window-button-minimize {
-  background : url('default/wm/minimize_unfocused.png') no-repeat center center,
-               url('default/wm/minimize.png') no-repeat center center !important;
+  background : url('dark/wm/minimize_unfocused.png') no-repeat center center,
+               url('dark/wm/minimize.png') no-repeat center center !important;
 }
 application-window-button-minimize:hover {
-  background : url('default/wm/minimize_unfocused_prelight.png') no-repeat center center,
-               url('default/wm/minimize.png') no-repeat center center !important;
+  background : url('dark/wm/minimize_unfocused_prelight.png') no-repeat center center,
+               url('dark/wm/minimize.png') no-repeat center center !important;
 }
 application-window-button-minimize:active {
-  background : url('default/wm/minimize_unfocused_pressed.png') no-repeat center center,
-               url('default/wm/minimize.png') no-repeat center center !important;
+  background : url('dark/wm/minimize_unfocused_pressed.png') no-repeat center center,
+               url('dark/wm/minimize.png') no-repeat center center !important;
 }
 
 application-window[data-focused="true"] application-window-button-minimize {
-  background : url('default/wm/minimize_focused_normal.png') no-repeat center center,
-               url('default/wm/minimize.png') no-repeat center center !important;
+  background : url('dark/wm/minimize_focused_normal.png') no-repeat center center,
+               url('dark/wm/minimize.png') no-repeat center center !important;
 }
 application-window[data-focused="true"] application-window-button-minimize:hover {
-  background : url('default/wm/minimize_focused_prelight.png') no-repeat center center,
-               url('default/wm/minimize.png') no-repeat center center !important;
+  background : url('dark/wm/minimize_focused_prelight.png') no-repeat center center,
+               url('dark/wm/minimize.png') no-repeat center center !important;
 }
 application-window[data-focused="true"] application-window-button-minimize:active {
-  background : url('default/wm/minimize_focused_pressed.png') no-repeat center center,
-               url('default/wm/minimize.png') no-repeat center center !important;
+  background : url('dark/wm/minimize_focused_pressed.png') no-repeat center center,
+               url('dark/wm/minimize.png') no-repeat center center !important;
 }
 
 /* Close */
 application-window-button-close {
-  background : url('default/wm/close_unfocused.png') no-repeat center center,
-               url('default/wm/close.png') no-repeat center center !important;
+  background : url('dark/wm/close_unfocused.png') no-repeat center center,
+               url('dark/wm/close.png') no-repeat center center !important;
 }
 application-window-button-close:hover {
-  background : url('default/wm/close_unfocused_prelight.png') no-repeat center center,
-               url('default/wm/close.png') no-repeat center center !important;
+  background : url('dark/wm/close_unfocused_prelight.png') no-repeat center center,
+               url('dark/wm/close.png') no-repeat center center !important;
 }
 application-window-button-close:active {
-  background : url('default/wm/close_unfocused_pressed.png') no-repeat center center,
-               url('default/wm/close.png') no-repeat center center !important;
+  background : url('dark/wm/close_unfocused_pressed.png') no-repeat center center,
+               url('dark/wm/close.png') no-repeat center center !important;
 }
 
 application-window[data-focused="true"] application-window-button-close {
-  background : url('default/wm/close_focused_normal.png') no-repeat center center,
-               url('default/wm/close.png') no-repeat center center !important;
+  background : url('dark/wm/close_focused_normal.png') no-repeat center center,
+               url('dark/wm/close.png') no-repeat center center !important;
 }
 application-window[data-focused="true"] application-window-button-close:hover {
-  background : url('default/wm/close_focused_prelight.png') no-repeat center center,
-               url('default/wm/close.png') no-repeat center center !important;
+  background : url('dark/wm/close_focused_prelight.png') no-repeat center center,
+               url('dark/wm/close.png') no-repeat center center !important;
 }
 application-window[data-focused="true"] application-window-button-close:active {
-  background : url('default/wm/close_focused_pressed.png') no-repeat center center,
-               url('default/wm/close.png') no-repeat center center !important;
+  background : url('dark/wm/close_focused_pressed.png') no-repeat center center,
+               url('dark/wm/close.png') no-repeat center center !important;
 }
 


### PR DESCRIPTION
The `dark` theme should use the assert from the `dark` theme and not the once from the `default` theme.