### PR TITLE
Get correct type for APIResponse::ErrorHandler

### DIFF
--- a/src/server/php/api.php
+++ b/src/server/php/api.php
@@ -237,10 +237,10 @@ class APIResponse
         case E_CORE_WARNING: // 32
           $type = 'E_CORE_WARNING';
         break;
-        case E_CORE_ERROR: // 64
+        case E_COMPILE_ERROR: // 64
           $type = 'E_COMPILE_ERROR';
         break;
-        case E_CORE_WARNING: // 128
+        case E_COMPILE_WARNING: // 128
           $type = 'E_COMPILE_WARNING';
         break;
         case E_USER_ERROR: // 256


### PR DESCRIPTION
Noticed there where multiple `E_CORE_ERROR` and `E_CORE_WARNING` cases.
So thought it might be a mistake?