### PR TITLE
Add sudo command in install-nix.md

### DIFF
--- a/doc/install-nix.md
+++ b/doc/install-nix.md
@@ -7,7 +7,7 @@ Make sure you have **all dependencies installed** before beginning.
 ## Automated
 
 ```
-$ curl -sS https://os.js.org/installer | sh
+$ curl -sS https://os.js.org/installer | sudo sh
 ```
 
 ## Manual


### PR DESCRIPTION
The sudo command is required to install dependencies on *nix systems.