### PR TITLE
Quiet delete windows symlinks if already exist

### DIFF
--- a/bin/create-windows-symlinks.cmd
+++ b/bin/create-windows-symlinks.cmd
@@ -4,10 +4,10 @@ cd "%folder%"
 
 cd dist-dev
 
-del client
-del themes
-del vendor
-del packages
+del /f /q client
+del /f /q themes
+del /f /q vendor
+del /f /q packages
 
 mklink /D client ..\src\client
 mklink /D themes ..\dist\themes


### PR DESCRIPTION
Proposed changes in this pull-request:

-In create-windows-symlinks.cmd script, do a quiet delete if symlinks already exist
-
-

---

*Please make sure that you read the guidelines and test your code before submission, or else your request might be rejected*
