### PR TITLE
Ensure the directory tree exists when writing settings file

### DIFF
--- a/src/server/node/modules/storage/system.js
+++ b/src/server/node/modules/storage/system.js
@@ -61,12 +61,17 @@ module.exports.setSettings = function(http, username, settings) {
   });
 
   return new Promise(function(resolve, reject) {
-    _fs.writeFile(path, JSON.stringify(settings), function(err, res) {
-      if ( err ) {
-        reject(err);
-      } else {
-        resolve(true);
+    _fs.ensureFile(path, (err) => {
+      if (err) {
+        return reject(err);
       }
+      _fs.writeFile(path, JSON.stringify(settings), function(err, res) {
+        if ( err ) {
+          reject(err);
+        } else {
+          resolve(true);
+        }
+      });
     });
   });
 };

--- a/src/server/node/modules/storage/system.js
+++ b/src/server/node/modules/storage/system.js
@@ -61,7 +61,7 @@ module.exports.setSettings = function(http, username, settings) {
   });
 
   return new Promise(function(resolve, reject) {
-    _fs.ensureFile(path, (err) => {
+    _fs.ensureFile(path, function(err) {
       if (err) {
         return reject(err);
       }


### PR DESCRIPTION
Proposed changes in this pull-request:

- Ensure the directory tree exists when writing settings file by calling fs-extra.ensureFile

---

*Please make sure that you read the guidelines and test your code before submission, or else your request might be rejected*
