### PR TITLE
Set draggable for desktop by default

### DIFF
--- a/src/packages/default/CoreWM/iconview.js
+++ b/src/packages/default/CoreWM/iconview.js
@@ -119,6 +119,7 @@
     this.$iconview = null;
     this.$element = document.createElement('gui-icon-view');
     this.$element.setAttribute('data-multiple', 'false');
+    this.$element.setAttribute('data-draggable', 'true');
     //this.$element.setAttribute('no-selection', 'true');
     this.$element.id = 'CoreWMDesktopIconView';
     this.shortcutCache = [];


### PR DESCRIPTION
Proposed changes in this pull-request:

- Fixed default draggable for desktop dataview/iconview.