### PR TITLE
Resolves #608

### DIFF
--- a/src/conf/300-mime.json
+++ b/src/conf/300-mime.json
@@ -13,6 +13,7 @@
       "text/xml"                : "XML Document",
       "application/javascript"  : "JavaScript Document",
       "application/json"        : "JSON Document",
+      "application/font-woff" : "Woff font file",
       "application/x-python"    : "Python Document",
       "application/x-lua"       : "Lua Document",
       "application/x-shellscript": "Shell Script",
@@ -60,6 +61,7 @@
       ".cc"     : "text/x-cplusplus",
       ".otf"    : "font/opentype",
       ".ttf"    : "font/opentype",
+      ".woff" : "application/font-woff",
       ".png"    : "image/png",
 
       ".zip"    : "application/zip",


### PR DESCRIPTION
Resolves #608 

- It seems in nodejs 8 it is forbidden to have empty headers
- Woff files are not mapped to any content-type so their header becomes
  undefined and it raises this error: UNCAUGHT EXCEPTION Error: Header "%s" value must not be undefined

