### PR TITLE
Adding missing paremeter for destroyIcon

### DIFF
--- a/src/client/javascript/gui/notification.js
+++ b/src/client/javascript/gui/notification.js
@@ -201,7 +201,7 @@ class Notification {
    * @param   {String}    name      Internal name (unique)
    * @return {Boolean}
    */
-  destroyIcon() {
+  destroyIcon(name) {
     const wm = WindowManager.instance;
     if ( wm && typeof wm.getNotificationArea === 'function' ) {
       const pitem = wm.getNotificationArea();


### PR DESCRIPTION
Proposed changes in this pull-request:

- Adding missing paremeter for `destroyIcon()` in `gui\notification.js`