### PR TITLE
GUI: Fix wrong class name in elements/treeview.js

### DIFF
--- a/src/client/javascript/gui/elements/treeview.js
+++ b/src/client/javascript/gui/elements/treeview.js
@@ -278,7 +278,7 @@ class GUITreeView extends GUIDataView {
 
   patch(entries) {
     const body = this.$element.querySelector('gui-tree-view-body');
-    return super.patch(entries, 'gui-list-view-entry', body, createEntry, initEntry);
+    return super.patch(entries, 'gui-tree-view-entry', body, createEntry, initEntry);
   }
 
   expand(entry) {


### PR DESCRIPTION
Changes in this pull-request:

- Fixing the className argument in patch() of elements/treeview.js.