### PR TITLE
Add default values for env vars in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,14 +40,14 @@ services:
     build:
       context: .
       args:
-        - NODE_ENV=${DOCKER_NODE_ENV}
+        - NODE_ENV=${DOCKER_NODE_ENV:-development}
         - DOCKER_UID=${DOCKER_UID:-1000}
         - DOCKER_GID=${DOCKER_GID:-1000}
     environment:
-      - NODE_ENV=${DOCKER_NODE_ENV}
+      - NODE_ENV=${DOCKER_NODE_ENV:-development}
     command: nodemon --watch package-lock.json --watch src/server --watch src/packages src/server/index.js
     volumes:
       - ./src:/usr/src/osjs/src
       - ./vfs:/usr/src/osjs/vfs
     ports:
-      - "${DOCKER_NODE_PORT}:8000"
+      - "${DOCKER_NODE_PORT:-8000}:8000"


### PR DESCRIPTION
Add default values for environment variables in `docker-compose.yml`. This will allow to test OS.js in services like [Play with Docker](https://labs.play-with-docker.com/).